### PR TITLE
fix autosar version case and add missing type stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ from autosar_data import *
 model = AutosarModel()
 
 # create a file in the model
-file1 = model.create_file("filename.arxml", AutosarVersion.Autosar_4_3_0)
+file1 = model.create_file("filename.arxml", AutosarVersion.AUTOSAR_4_3_0)
 # a model can consist of multiple files - elements appear in all of them by default, unless restrictions are set
-file2 = model.create_file("filename2.arxml", AutosarVersion.Autosar_00051)
+file2 = model.create_file("filename2.arxml", AutosarVersion.AUTOSAR_00051)
 
 # initially the model only has its root element, <AUTOSAR>. Create some elements
 el_elements = model.root_element \

--- a/autosar_data.pyi
+++ b/autosar_data.pyi
@@ -139,26 +139,28 @@ class AutosarVersion:
     """
     def __new__(cls, verstring: str) -> AutosarVersion: ...
     # this is the stupid result of method used by PyO3 to translate Rust enums
-    Autosar_4_0_1: AutosarVersion
-    Autosar_4_0_2: AutosarVersion
-    Autosar_4_0_3: AutosarVersion
-    Autosar_4_1_1: AutosarVersion
-    Autosar_4_1_2: AutosarVersion
-    Autosar_4_1_3: AutosarVersion
-    Autosar_4_2_1: AutosarVersion
-    Autosar_4_2_2: AutosarVersion
-    Autosar_4_3_0: AutosarVersion
-    Autosar_00042: AutosarVersion
-    Autosar_00043: AutosarVersion
-    Autosar_00044: AutosarVersion
-    Autosar_00045: AutosarVersion
-    Autosar_00046: AutosarVersion
-    Autosar_00047: AutosarVersion
-    Autosar_00048: AutosarVersion
-    Autosar_00049: AutosarVersion
-    Autosar_00050: AutosarVersion
-    Autosar_00051: AutosarVersion
-    Autosar_00052: AutosarVersion
+    AUTOSAR_4_0_1: AutosarVersion
+    AUTOSAR_4_0_2: AutosarVersion
+    AUTOSAR_4_0_3: AutosarVersion
+    AUTOSAR_4_1_1: AutosarVersion
+    AUTOSAR_4_1_2: AutosarVersion
+    AUTOSAR_4_1_3: AutosarVersion
+    AUTOSAR_4_2_1: AutosarVersion
+    AUTOSAR_4_2_2: AutosarVersion
+    AUTOSAR_4_3_0: AutosarVersion
+    AUTOSAR_00042: AutosarVersion
+    AUTOSAR_00043: AutosarVersion
+    AUTOSAR_00044: AutosarVersion
+    AUTOSAR_00045: AutosarVersion
+    AUTOSAR_00046: AutosarVersion
+    AUTOSAR_00047: AutosarVersion
+    AUTOSAR_00048: AutosarVersion
+    AUTOSAR_00049: AutosarVersion
+    AUTOSAR_00050: AutosarVersion
+    AUTOSAR_00051: AutosarVersion
+    AUTOSAR_00052: AutosarVersion
+    AUTOSAR_00053: AutosarVersion
+    LATEST: AutosarVersion
 
 class ContentType:
     """

--- a/docs/index.md
+++ b/docs/index.md
@@ -548,25 +548,27 @@ a path listing all xml elements from the root of the model to the element. This 
 
 A version of the Autosar standard
 
-- Autosar_4_0_1
-- Autosar_4_0_2
-- Autosar_4_0_3
-- Autosar_4_1_1
-- Autosar_4_1_2
-- Autosar_4_1_3
-- Autosar_4_2_1
-- Autosar_4_2_2
-- Autosar_4_3_0
-- Autosar_00042
-- Autosar_00043
-- Autosar_00044
-- Autosar_00045
-- Autosar_00046
-- Autosar_00047
-- Autosar_00048
-- Autosar_00049
-- Autosar_00050
-- Autosar_00051
+- AUTOSAR_4_0_1
+- AUTOSAR_4_0_2
+- AUTOSAR_4_0_3
+- AUTOSAR_4_1_1
+- AUTOSAR_4_1_2
+- AUTOSAR_4_1_3
+- AUTOSAR_4_2_1
+- AUTOSAR_4_2_2
+- AUTOSAR_4_3_0
+- AUTOSAR_00042
+- AUTOSAR_00043
+- AUTOSAR_00044
+- AUTOSAR_00045
+- AUTOSAR_00046
+- AUTOSAR_00047
+- AUTOSAR_00048
+- AUTOSAR_00049
+- AUTOSAR_00050
+- AUTOSAR_00051
+- AUTOSAR_00052
+- AUTOSAR_00053
 
 ```python
 LATEST


### PR DESCRIPTION
This addresses only the type stubs and docs, but not `repr()`, as discussed in #9.